### PR TITLE
Add `dart_dot_reporter` package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  dart_dot_reporter:
+    dependency: "direct main"
+    description:
+      name: dart_dot_reporter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  dart_dot_reporter: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🌈 Summary

- [`dart_dot_reporter`](https://pub.dev/packages/dart_dot_reporter) パッケージの追加

## 🎯 Details

- 今度はテスト結果の可読性をぐいっとあげる

### ⭐️ How to use

```
$ flutter test --machine > machine.log
$ flutter pub global run dart_dot_reporter machine.log --show-success --show-id
```

## 📸 Images

### Before

- 成功

<img width="300" alt="スクリーンショット 2021-10-20 0 28 23" src="https://user-images.githubusercontent.com/2792420/137942706-9bce9023-66c1-4ad3-a1d7-28711f715960.png">

- 失敗

<img width="800" alt="スクリーンショット 2021-10-20 0 28 47" src="https://user-images.githubusercontent.com/2792420/137942790-01529f42-03c3-456f-9284-82591f879db6.png">

### After

- 成功

<img width="370" alt="スクリーンショット 2021-10-20 0 29 44" src="https://user-images.githubusercontent.com/2792420/137942969-01253c57-47c6-4c1c-827c-ac556f426cc5.png">

- 失敗

<img width="800" alt="スクリーンショット 2021-10-20 0 30 14" src="https://user-images.githubusercontent.com/2792420/137943041-91efbe03-dd66-4002-9e8f-18a3d30b8027.png">