### PR TITLE
Add `given_when_then` and rewrite tests

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  given_when_then:
+    dependency: "direct main"
+    description:
+      name: given_when_then
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   dart_dot_reporter: ^1.0.4
+  given_when_then: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,79 +1,107 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:readable_test/main.dart';
+import 'widget_test_helper.dart';
 
 void main() {
   group('[Increment Button]', () {
     group('label shows "0"', () {
-      testWidgets('label shows "1"', (WidgetTester tester) async {
-        await tester.pumpWidget(const MyApp());
+      testWidgets(
+        'label shows "1"',
+        harness((given, when, then) async {
+          {
+            await given.pumpMyApp();
+            given.canFindZero();
+            given.cannotFindOne();
+          }
 
-        expect(find.text('0'), findsOneWidget);
-        expect(find.text('1'), findsNothing);
+          {
+            await when.userTapsIncrementButton();
+          }
 
-        await tester.tap(find.byKey(incrementKey));
-        await tester.pump();
-
-        expect(find.text('0'), findsNothing);
-        expect(find.text('1'), findsOneWidget);
-      });
+          {
+            then.cannotFindZero();
+            then.canFindOne();
+          }
+        }),
+      );
     });
 
     group('label shows "1"', () {
-      testWidgets('label shows "2"', (WidgetTester tester) async {
-        await tester.pumpWidget(const MyApp());
+      testWidgets(
+        'label shows "2"',
+        harness((given, when, then) async {
+          {
+            await given.pumpMyApp();
+            await given.increment();
+            await given.pump();
 
-        await tester.tap(find.byKey(incrementKey));
-        await tester.pump();
+            given.canFindOne();
+            given.cannotFindTwo();
+          }
 
-        expect(find.text('1'), findsOneWidget);
-        expect(find.text('2'), findsNothing);
+          {
+            await when.userTapsIncrementButton();
+          }
 
-        await tester.tap(find.byKey(incrementKey));
-        await tester.pump();
-
-        expect(find.text('1'), findsNothing);
-        expect(find.text('2'), findsOneWidget);
-      });
+          {
+            then.cannotFindOne();
+            then.canFindTwo();
+          }
+        }),
+      );
     });
   });
 
   group('[Decrement Button]', () {
     group('label shows "1"', () {
-      testWidgets('label shows "0"', (WidgetTester tester) async {
-        await tester.pumpWidget(const MyApp());
+      testWidgets(
+        'label shows "0"',
+        harness((given, when, then) async {
+          {
+            await given.pumpMyApp();
+            await given.increment();
+            await given.pump();
 
-        await tester.tap(find.byKey(incrementKey));
-        await tester.pump();
+            given.canFindOne();
+            given.cannotFindZero();
+          }
 
-        expect(find.text('1'), findsOneWidget);
-        expect(find.text('0'), findsNothing);
+          {
+            await when.userTapsDecrementButton();
+          }
 
-        await tester.tap(find.byKey(decrementKey));
-        await tester.pump();
-
-        expect(find.text('0'), findsOneWidget);
-        expect(find.text('1'), findsNothing);
-      });
+          {
+            then.cannotFindOne();
+            then.canFindZero();
+          }
+        }),
+      );
     });
 
     group('label shows "2"', () {
-      testWidgets('label shows "1"', (WidgetTester tester) async {
-        await tester.pumpWidget(const MyApp());
+      testWidgets(
+        'label shows "1"',
+        harness((given, when, then) async {
+          {
+            await given.pumpMyApp();
+            await given.increment();
+            await given.increment();
+            await given.pump();
 
-        await tester.tap(find.byKey(incrementKey));
-        await tester.tap(find.byKey(incrementKey));
-        await tester.pump();
+            given.canFindTwo();
+            given.cannotFindOne();
+          }
 
-        expect(find.text('2'), findsOneWidget);
-        expect(find.text('1'), findsNothing);
+          {
+            await when.userTapsDecrementButton();
+          }
 
-        await tester.tap(find.byKey(decrementKey));
-        await tester.pump();
-
-        expect(find.text('2'), findsNothing);
-        expect(find.text('1'), findsOneWidget);
-      });
+          {
+            then.cannotFindTwo();
+            then.canFindOne();
+          }
+        }),
+      );
     });
   });
 }

--- a/test/widget_test_helper.dart
+++ b/test/widget_test_helper.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:given_when_then/given_when_then.dart';
+
+import 'package:readable_test/main.dart';
+
+Future<void> Function(WidgetTester) harness(
+  WidgetTestHarnessCallback<_MyAppTestHarness> callback,
+) {
+  return (tester) =>
+      givenWhenThenWidgetTest(_MyAppTestHarness(tester), callback);
+}
+
+class _MyAppTestHarness extends WidgetTestHarness {
+  _MyAppTestHarness(WidgetTester tester) : super(tester);
+}
+
+extension MyAppGiven on WidgetTestGiven<_MyAppTestHarness> {
+  Future<void> pumpMyApp() async {
+    await tester.pumpWidget(const MyApp());
+  }
+
+  Future<void> increment() async {
+    await tester.tap(find.byKey(incrementKey));
+  }
+
+  Future<void> pump() async {
+    await tester.pump();
+  }
+
+  void canFindZero() {
+    expect(find.text('0'), findsOneWidget);
+  }
+
+  void cannotFindZero() {
+    expect(find.text('0'), findsNothing);
+  }
+
+  void canFindOne() {
+    expect(find.text('1'), findsOneWidget);
+  }
+
+  void cannotFindOne() {
+    expect(find.text('1'), findsNothing);
+  }
+
+  void canFindTwo() {
+    expect(find.text('2'), findsOneWidget);
+  }
+
+  void cannotFindTwo() {
+    expect(find.text('2'), findsNothing);
+  }
+}
+
+extension MyAppWhen on WidgetTestWhen<_MyAppTestHarness> {
+  Future<void> userTapsIncrementButton() async {
+    await tester.tap(find.byKey(incrementKey));
+    await tester.pump();
+  }
+
+  Future<void> userTapsDecrementButton() async {
+    await tester.tap(find.byKey(decrementKey));
+    await tester.pump();
+  }
+}
+
+extension MyAppThen on WidgetTestThen<_MyAppTestHarness> {
+  void canFindZero() {
+    expect(find.text('0'), findsOneWidget);
+  }
+
+  void cannotFindZero() {
+    expect(find.text('0'), findsNothing);
+  }
+
+  void canFindOne() {
+    expect(find.text('1'), findsOneWidget);
+  }
+
+  void cannotFindOne() {
+    expect(find.text('1'), findsNothing);
+  }
+
+  void canFindTwo() {
+    expect(find.text('2'), findsOneWidget);
+  }
+
+  void cannotFindTwo() {
+    expect(find.text('2'), findsNothing);
+  }
+}


### PR DESCRIPTION
## 🌈 Summary

- [`given_when_then`](https://pub.dev/packages/given_when_then) パッケージの追加
- `given_when_then` 形式にテストを書き換え

## 🎯 Details

- `given_when_then` 用の `helper` クラスの作成

### Before

```dart
testWidgets('label shows "1"', (WidgetTester tester) {
  await tester.pumpWidget(const MyApp());

  expect(find.text('0'), findsOneWidget);
  expect(find.text('1'), findsNothing);

  await tester.tap(find.byKey(incrementKey));
  await tester.pump();

  expect(find.text('0'), findsNothing);
  expect(find.text('1'), findsOneWidget);
});
```

### After

```dart
testWidgets('label shows "1"', harness((given, when, then) async {
  {
    await given.pumpMyApp();
    given.canFindZero();
    given.cannotFindOne();
  }

  {
    await when.userTapsIncrementButton();
  }

  {
    then.cannotFindZero();
    then.canFindOne();
  }
}));
```

※ほぼ自明だと思うが、 `{ }` は各節を明確にするため追加しているだけで必ずしも必要ではない

## 📚 Appendix

- `widget_test_helper.dart` の `_MyAppTestHarness` に相当するクラスは一つのコンポーネントにつき一つ作成すれば良さそう
- `xxxGiven` / `xxxWhen` / `xxxThen` はそのコンポーネントに必要なメソッドを全て定義する感じになりそう
  - それぞれのテストで必要なメソッドのみを使う