### PR TITLE
Add `flutter_test_ui` and rewrite tests

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_test_ui:
+    dependency: "direct main"
+    description:
+      name: flutter_test_ui
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   given_when_then:
     dependency: "direct main"
     description:
@@ -179,3 +186,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   dart_dot_reporter: ^1.0.4
   given_when_then: ^0.2.0
+  flutter_test_ui: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,15 +1,20 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_ui/flutter_test_ui.dart';
+import 'package:readable_test/main.dart';
 
 import 'widget_test_helper.dart';
 
 void main() {
+  setUpUI((tester) async {
+    await tester.pumpWidget(const MyApp());
+  });
+
   group('[Increment Button]', () {
     group('label shows "0"', () {
-      testWidgets(
+      testUI(
         'label shows "1"',
         harness((given, when, then) async {
           {
-            await given.pumpMyApp();
             given.canFindZero();
             given.cannotFindOne();
           }
@@ -27,14 +32,15 @@ void main() {
     });
 
     group('label shows "1"', () {
-      testWidgets(
+      setUpUI((tester) async {
+        await tester.tap(find.byKey(incrementKey));
+        await tester.pump();
+      });
+
+      testUI(
         'label shows "2"',
         harness((given, when, then) async {
           {
-            await given.pumpMyApp();
-            await given.increment();
-            await given.pump();
-
             given.canFindOne();
             given.cannotFindTwo();
           }
@@ -54,14 +60,15 @@ void main() {
 
   group('[Decrement Button]', () {
     group('label shows "1"', () {
-      testWidgets(
+      setUpUI((tester) async {
+        await tester.tap(find.byKey(incrementKey));
+        await tester.pump();
+      });
+
+      testUI(
         'label shows "0"',
         harness((given, when, then) async {
           {
-            await given.pumpMyApp();
-            await given.increment();
-            await given.pump();
-
             given.canFindOne();
             given.cannotFindZero();
           }
@@ -79,15 +86,16 @@ void main() {
     });
 
     group('label shows "2"', () {
-      testWidgets(
+      setUpUI((tester) async {
+        await tester.tap(find.byKey(incrementKey));
+        await tester.tap(find.byKey(incrementKey));
+        await tester.pump();
+      });
+
+      testUI(
         'label shows "1"',
         harness((given, when, then) async {
           {
-            await given.pumpMyApp();
-            await given.increment();
-            await given.increment();
-            await given.pump();
-
             given.canFindTwo();
             given.cannotFindOne();
           }


### PR DESCRIPTION
## 🌈 Summary

- [`flutter_test_ui`](https://pub.dev/packages/flutter_test_ui)  パッケージの追加
- 既存テストの書き換え

## 🎯 Details

- UIテストの共通処理などを `setUpUI` メソッドなどにまとめた
  - この関係で `given_when_then` が使えなくなるのはちょっと考え所🤔

### Before

```dart
void main() {
  group('[Increment Button]', () {
    group('label shows "0"', () {
      testWidgets(
        'label shows "1"',
        harness((given, when, then) async {
          {
            await given.pumpMyApp();
            given.canFindZero();
            given.cannotFindOne();
          }

          {
            await when.userTapsIncrementButton();
          }

          {
            then.cannotFindZero();
            then.canFindOne();
          }
        }),
      );
    });
  });
}
```

### After

```dart
void main() {
  setUpUI((tester) async {
    await tester.pumpWidget(const MyApp());
  });

  group('[Increment Button]', () {
    group('label shows "0"', () {
      testUI(
        'label shows "1"',
        harness((given, when, then) async {
          {
            given.canFindZero();
            given.cannotFindOne();
          }

          {
            await when.userTapsIncrementButton();
          }

          {
            then.cannotFindZero();
            then.canFindOne();
          }
        }),
      );
    });
  });
}
```

## 📚 Appendix

- `testUI` のところは `testWidgets` のままだとテストが通らない(assertで引っかかる)のは注意